### PR TITLE
Allow script to run when neither name nor email is set

### DIFF
--- a/mbox_parser.py
+++ b/mbox_parser.py
@@ -48,6 +48,8 @@ if __name__ == "__main__":
             writer.writerow([message["subject"], message["from"], message["date"], contents])
         elif email_filter != "" and email_filter in message["from"]:
             writer.writerow([message["subject"], message["from"], message["date"], contents])
+        elif email_filter != "" and name_filter != "":
+            writer.writerow([message["subject"], message["from"], message["date"], contents])
         else:
             continue
 


### PR DESCRIPTION
Currently the script will not run properly if both name and email are empty, I expected the behaviour would be to output all emails.